### PR TITLE
Don't use JSONRPC namespace

### DIFF
--- a/Sources/WalletConnectSign/Services/HistoryService.swift
+++ b/Sources/WalletConnectSign/Services/HistoryService.swift
@@ -110,7 +110,7 @@ final class MockHistoryService: HistoryServiceProtocol {
         removePendingRequestCalled(topic)
     }
     
-    func getSessionRequest(id: JSONRPC.RPCID) -> (request: Request, context: VerifyContext?)? {
+    func getSessionRequest(id: RPCID) -> (request: Request, context: VerifyContext?)? {
         fatalError("Unimplemented")
     }
     


### PR DESCRIPTION
### SUMMARY
Using JSONRPC namespace causes compilation error and not needed at all